### PR TITLE
Improve language options readabilty in Dark Mode

### DIFF
--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -60,7 +60,7 @@ const LayoutWrapper = ({ children }) => {
               className="text-gray-900 dark:text-gray-100 text-shadow-sm text-sm bg-transparent tracking-wide"
             >
               {locales.map((e) => (
-                <option className="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100" value={e} key={e}>
+                <option className="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100" value={e} key={e}>
                   {e}
                 </option>
               ))}

--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -60,7 +60,7 @@ const LayoutWrapper = ({ children }) => {
               className="text-gray-900 dark:text-gray-100 text-shadow-sm text-sm bg-transparent tracking-wide"
             >
               {locales.map((e) => (
-                <option className="dark:text-gray-900" value={e} key={e}>
+                <option className="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100" value={e} key={e}>
                   {e}
                 </option>
               ))}

--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -60,7 +60,7 @@ const LayoutWrapper = ({ children }) => {
               className="text-gray-900 dark:text-gray-100 text-shadow-sm text-sm bg-transparent tracking-wide"
             >
               {locales.map((e) => (
-                <option className="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100" value={e} key={e}>
+                <option className="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100" value={e} key={e}>
                   {e}
                 </option>
               ))}

--- a/components/LayoutWrapper.js
+++ b/components/LayoutWrapper.js
@@ -60,7 +60,7 @@ const LayoutWrapper = ({ children }) => {
               className="text-gray-900 dark:text-gray-100 text-shadow-sm text-sm bg-transparent tracking-wide"
             >
               {locales.map((e) => (
-                <option value={e} key={e}>
+                <option className="dark:text-gray-900" value={e} key={e}>
                   {e}
                 </option>
               ))}


### PR DESCRIPTION
When the dropdown from the language select is opened in Dark Mode, the background is white, but the font color was `text-gray-100` making it difficult to read. Added the classname `bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100` to the option values making it easier to read and to match the dark mode.